### PR TITLE
Add support for gRPC client headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ You need to add the following `<dependencies>`:
 <dependency>
     <groupId>com.github.thinkerou</groupId>
     <artifactId>karate-grpc-core</artifactId>
-    <version>1.0.6</version>
+    <version>1.0.7</version>
 </dependency>
 ```
 
@@ -61,7 +61,7 @@ You need to add the following `<dependencies>`:
 Alternatively for Gradle you need to add the following entry:
 
 ```gradle
-testImplementation 'com.github.thinkerou:karate-grpc-core:1.0.6'
+testImplementation 'com.github.thinkerou:karate-grpc-core:1.0.7'
 ```
 
 And simulates `karate-grpc-helper` and `karate-grpc-demo` build your redis helper project and test project.

--- a/karate-grpc-core/pom.xml
+++ b/karate-grpc-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>karate-grpc-parent</artifactId>
         <groupId>com.github.thinkerou</groupId>
-        <version>1.0.6</version>
+        <version>1.0.7</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/karate-grpc-core/src/main/java/com/github/thinkerou/karate/GrpcClient.java
+++ b/karate-grpc-core/src/main/java/com/github/thinkerou/karate/GrpcClient.java
@@ -43,12 +43,12 @@ public class GrpcClient {
     /**
      * @param name name
      * @param payload payload
-     * @param scenarioBridge scenario bridge
+     * @param scenarioBridge Karate ScenarioBridge
      * @return string
      */
     public String call(String name, String payload, ScenarioBridge scenarioBridge) {
         logRequest(payload, scenarioBridge);
-        final String response = invokeCall(name, payload);
+        final String response = invokeCall(name, payload, scenarioBridge);
         logResponse(response, scenarioBridge);
         return response;
     }
@@ -116,8 +116,8 @@ public class GrpcClient {
         log.info(message);
     }
 
-    protected String invokeCall(String name, String payload) {
-        return callIns.invoke(name, payload);
+    protected String invokeCall(String name, String payload, ScenarioBridge scenarioBridge) {
+        return callIns.invoke(name, payload, scenarioBridge);
     }
 
     protected String invokeList(String name, Boolean withMessage) {

--- a/karate-grpc-core/src/main/java/com/github/thinkerou/karate/RedisGrpcClient.java
+++ b/karate-grpc-core/src/main/java/com/github/thinkerou/karate/RedisGrpcClient.java
@@ -1,6 +1,7 @@
 package com.github.thinkerou.karate;
 
 import com.github.thinkerou.karate.utils.RedisHelper;
+import com.intuit.karate.core.ScenarioBridge;
 
 /**
  * RedisGrpcClient
@@ -31,8 +32,8 @@ public class RedisGrpcClient extends GrpcClient {
     }
 
     @Override
-    protected String invokeCall(String name, String payload) {
-        return callIns.invokeByRedis(name, payload, redisHelper);
+    protected String invokeCall(String name, String payload, ScenarioBridge scenarioBridge) {
+        return callIns.invokeByRedis(name, payload, scenarioBridge, redisHelper);
     }
 
     @Override

--- a/karate-grpc-core/src/main/java/com/github/thinkerou/karate/grpc/ChannelFactory.java
+++ b/karate-grpc-core/src/main/java/com/github/thinkerou/karate/grpc/ChannelFactory.java
@@ -1,5 +1,6 @@
 package com.github.thinkerou.karate.grpc;
 
+import io.grpc.ClientInterceptor;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 
@@ -15,8 +16,11 @@ public final class ChannelFactory {
      * @param port grpc server port
      * @return managed channel
      */
-    public static ManagedChannel create(String host, int port) {
-        return ManagedChannelBuilder.forAddress(host, port).usePlaintext().build();
+    public static ManagedChannel create(String host, int port, ClientInterceptor interceptor) {
+        return ManagedChannelBuilder.forAddress(host, port)
+                .intercept(interceptor)
+                .usePlaintext()
+                .build();
     }
 
 }

--- a/karate-grpc-core/src/main/java/com/github/thinkerou/karate/grpc/GrpcClientRequestInterceptor.java
+++ b/karate-grpc-core/src/main/java/com/github/thinkerou/karate/grpc/GrpcClientRequestInterceptor.java
@@ -1,0 +1,47 @@
+package com.github.thinkerou.karate.grpc;
+
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ForwardingClientCall;
+import io.grpc.ForwardingClientCallListener.SimpleForwardingClientCallListener;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+
+public class GrpcClientRequestInterceptor implements ClientInterceptor {
+
+    private final Metadata requestMetadata;
+    private Metadata responseMetadata;
+
+    public Metadata getResponseMetadata() {
+        return responseMetadata;
+    }
+
+    public GrpcClientRequestInterceptor(Metadata metadata) {
+        this.requestMetadata = metadata;
+    }
+
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+            final MethodDescriptor<ReqT, RespT> methodDescriptor,
+            final CallOptions callOptions,
+            final Channel channel) {
+
+        return new ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(
+                channel.newCall(methodDescriptor, callOptions)) {
+
+            @Override
+            public void start(ClientCall.Listener<RespT> responseListener, Metadata headers) {
+                headers = requestMetadata;
+                super.start(new SimpleForwardingClientCallListener<RespT>(responseListener) {
+                    @Override
+                    public void onHeaders(Metadata headers) {
+                        responseMetadata = headers;
+                        super.onHeaders(headers);
+                    }
+                }, headers);
+
+            }
+        };
+    }
+}

--- a/karate-grpc-core/src/main/java/com/github/thinkerou/karate/service/GrpcCall.java
+++ b/karate-grpc-core/src/main/java/com/github/thinkerou/karate/service/GrpcCall.java
@@ -1,23 +1,23 @@
 package com.github.thinkerou.karate.service;
 
-import static com.google.protobuf.DescriptorProtos.FileDescriptorSet;
-import static com.google.protobuf.util.JsonFormat.TypeRegistry;
-
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.github.thinkerou.karate.constants.DescriptorFile;
 import com.github.thinkerou.karate.domain.ProtoName;
 import com.github.thinkerou.karate.grpc.ChannelFactory;
 import com.github.thinkerou.karate.grpc.ComponentObserver;
 import com.github.thinkerou.karate.grpc.DynamicClient;
+import com.github.thinkerou.karate.grpc.GrpcClientRequestInterceptor;
 import com.github.thinkerou.karate.message.Reader;
 import com.github.thinkerou.karate.protobuf.ProtoFullName;
 import com.github.thinkerou.karate.protobuf.ServiceResolver;
@@ -25,12 +25,19 @@ import com.github.thinkerou.karate.utils.FileHelper;
 import com.github.thinkerou.karate.utils.RedisHelper;
 import com.google.common.collect.ImmutableList;
 import com.google.gson.Gson;
+import com.google.protobuf.DescriptorProtos.FileDescriptorSet;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.DynamicMessage;
+import com.google.protobuf.util.JsonFormat.TypeRegistry;
+import com.intuit.karate.core.ScenarioBridge;
+import com.intuit.karate.core.ScenarioEngine;
+import com.intuit.karate.core.Variable;
 import com.github.thinkerou.karate.message.Writer;
 
 import io.grpc.CallOptions;
+import io.grpc.ClientInterceptor;
 import io.grpc.ManagedChannel;
+import io.grpc.Metadata;
 import io.grpc.stub.StreamObserver;
 
 /**
@@ -40,9 +47,10 @@ import io.grpc.stub.StreamObserver;
  */
 public final class GrpcCall {
 
-    private static final Logger logger = Logger.getLogger(GrpcCall.class.getName());
+    protected static final Logger logger = LoggerFactory.getLogger(GrpcCall.class);
 
-    private final ManagedChannel channel;
+    private final String host;
+    private final int port;
 
     /**
      * @param host host
@@ -59,35 +67,48 @@ public final class GrpcCall {
      * @param port port
      */
     public GrpcCall(String host, int port) {
-        channel = ChannelFactory.create(host, port);
+        this.host = host;
+        this.port = port;
     }
 
     /**
-     * @param name name
+     * @param name    name
      * @param payload payload
      * @return string
      */
     public String invoke(String name, String payload) {
-        return execute(name, payload, null);
+        return execute(name, payload, null, null);
     }
 
     /**
-     * @param name name
-     * @param payload payload
-     * @param redisHelper redis helper
+     * @param name           name
+     * @param payload        payload
+     * @param scenarioBridge Karate ScenarioBridge
      * @return string
      */
-    public String invokeByRedis(String name, String payload, RedisHelper redisHelper) {
-        return execute(name, payload, redisHelper);
+    public String invoke(String name, String payload, ScenarioBridge scenarioBridge) {
+        return execute(name, payload, scenarioBridge, null);
     }
 
     /**
-     * @param name indicates one called grpc service full name, like: package.service/method
-     * @param payload indicates one protobuf corresponding json data
+     * @param name        name
+     * @param payload     payload
      * @param redisHelper redis helper
      * @return string
      */
-    private String execute(String name, String payload, RedisHelper redisHelper) {
+    public String invokeByRedis(String name, String payload, ScenarioBridge scenarioBridge, RedisHelper redisHelper) {
+        return execute(name, payload, scenarioBridge, redisHelper);
+    }
+
+    /**
+     * @param name           indicates one called grpc service full name, like:
+     *                       package.service/method
+     * @param payload        indicates one protobuf corresponding json data
+     * @param scenarioBridge the Karate ScenarioBridge
+     * @param redisHelper    redis helper
+     * @return string
+     */
+    private String execute(String name, String payload, ScenarioBridge scenarioBridge, RedisHelper redisHelper) {
         ProtoName protoName = ProtoFullName.parse(name);
         byte[] data;
         if (redisHelper != null) {
@@ -123,7 +144,7 @@ public final class GrpcCall {
             String result1 = list.invoke(protoName.getServiceName(), "", false);
             String result2 = list.invoke("", protoName.getMethodName(), false);
             if (!result1.equals("[]") || !result2.equals("[{}]")) {
-                logger.warning("Call grpc failed, maybe you should see the follow grpc information.");
+                logger.warn("Call grpc failed, maybe you should see the follow grpc information.");
                 if (!result1.equals("[]")) {
                     logger.info(result1);
                 }
@@ -134,10 +155,24 @@ public final class GrpcCall {
             throw new IllegalArgumentException(e.getMessage());
         }
 
+        Metadata metadata = new Metadata();
+        if (scenarioBridge != null) {
+            Variable headers = scenarioBridge.getEngine().getConfig().getHeaders();
+            if (headers != null && headers.isMap()) {
+                Map<String, String> headerMap = headers.getValue();
+                for (Map.Entry<String, String> entry : headerMap.entrySet()) {
+                    metadata.put(Metadata.Key.of(entry.getKey(), Metadata.ASCII_STRING_MARSHALLER), entry.getValue());
+                }
+            }
+        }
+
+        ClientInterceptor interceptor = new GrpcClientRequestInterceptor(metadata);
+        ManagedChannel channel = ChannelFactory.create(host, port, interceptor);
         // Create a dynamic grpc client.
         DynamicClient dynamicClient = DynamicClient.create(methodDescriptor, channel);
 
-        // This collects all know types into a registry for resolution of potential "Any" types.
+        // This collects all know types into a registry for resolution of potential
+        // "Any" types.
         TypeRegistry registry = TypeRegistry.newBuilder().add(serviceResolver.listMessageTypes()).build();
 
         // Convert payload string to list.
@@ -145,15 +180,14 @@ public final class GrpcCall {
 
         // Need to support stream so it's a list.
         final ImmutableList<DynamicMessage> requestMessages = Reader.create(
-                methodDescriptor.getInputType(), payloadList, registry
-        ).read();
+                methodDescriptor.getInputType(), payloadList, registry).read();
 
         // Creates one temp file to save call grpc result.
         Path filePath = null;
         try {
             filePath = Files.createTempFile("karate.grpc.", ".call.result");
         } catch (IOException e) {
-            logger.warning(e.getMessage());
+            logger.warn(e.getMessage());
         }
         FileHelper.validatePath(Optional.ofNullable(filePath));
 
@@ -164,9 +198,19 @@ public final class GrpcCall {
         try {
             dynamicClient.call(requestMessages, streamObserver, callOptions()).get();
         } catch (Throwable t) {
+            logger.error(t.getMessage());
             throw new RuntimeException("Caught exception while waiting for rpc", t);
         }
 
+        // Expose response headers to Karate's ScenarioBridge.
+        if (scenarioBridge != null) {
+            Metadata responseMetadata = ((GrpcClientRequestInterceptor) interceptor).getResponseMetadata();
+            Map<String, List<String>> headers = new HashMap();
+            responseMetadata.keys().forEach(key -> {
+                headers.put(key, ImmutableList.of(responseMetadata.get(Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER))));
+            });
+            scenarioBridge.getEngine().setVariable(ScenarioEngine.RESPONSE_HEADERS, headers);
+        }
         return output.toString();
     }
 

--- a/karate-grpc-demo/pom.xml
+++ b/karate-grpc-demo/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>karate-grpc-parent</artifactId>
         <groupId>com.github.thinkerou</groupId>
-        <version>1.0.6</version>
+        <version>1.0.7</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/karate-grpc-demo/src/main/java/com/github/thinkerou/demo/helloworld/HeaderServerInterceptor.java
+++ b/karate-grpc-demo/src/main/java/com/github/thinkerou/demo/helloworld/HeaderServerInterceptor.java
@@ -1,0 +1,37 @@
+package com.github.thinkerou.demo.helloworld;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.grpc.ForwardingServerCall.SimpleForwardingServerCall;
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class HeaderServerInterceptor implements ServerInterceptor {
+
+    private static final Logger logger = LoggerFactory.getLogger(HeaderServerInterceptor.class);
+
+    @VisibleForTesting
+    static final Metadata.Key<String> CUSTOM_HEADER_KEY = Metadata.Key.of("karate-test-server-header",
+            Metadata.ASCII_STRING_MARSHALLER);
+
+    @Override
+    public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+            ServerCall<ReqT, RespT> call,
+            final Metadata requestHeaders,
+            ServerCallHandler<ReqT, RespT> next) {
+        logger.debug("Headers received from client: {}", requestHeaders);
+        String clientSpecialHeaderValue = requestHeaders
+                .get(Metadata.Key.of("karate-test-header", Metadata.ASCII_STRING_MARSHALLER));
+        return next.startCall(new SimpleForwardingServerCall<ReqT, RespT>(call) {
+            @Override
+            public void sendHeaders(Metadata responseHeaders) {
+                logger.debug("Found special header value: {}", clientSpecialHeaderValue);
+                responseHeaders.put(CUSTOM_HEADER_KEY, clientSpecialHeaderValue);
+                super.sendHeaders(responseHeaders);
+            }
+        }, requestHeaders);
+    }
+}

--- a/karate-grpc-demo/src/main/java/com/github/thinkerou/demo/helloworld/HelloWorldServerMain.java
+++ b/karate-grpc-demo/src/main/java/com/github/thinkerou/demo/helloworld/HelloWorldServerMain.java
@@ -2,6 +2,8 @@ package com.github.thinkerou.demo.helloworld;
 
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
+import io.grpc.ServerInterceptors;
+
 import java.io.IOException;
 import java.util.List;
 import java.util.logging.Logger;
@@ -30,10 +32,10 @@ public class HelloWorldServerMain {
         String payloads = FileHelper.readFile(file);
 
         server = ServerBuilder.forPort(port)
-                .addService(new HelloWorldServerImpl(parseFeatures(payloads)))
+                .addService(ServerInterceptors.intercept(new HelloWorldServerImpl(parseFeatures(payloads)), new HeaderServerInterceptor()))
                 .build()
                 .start();
-        logger.info("Server started listening on " + port);
+        logger.info(() -> "Server started listening on " + port);
 
         Runtime.getRuntime().addShutdownHook(new Thread() {
             @Override

--- a/karate-grpc-demo/src/test/java/demo/helloworld/HelloWorldRawRunner.java
+++ b/karate-grpc-demo/src/test/java/demo/helloworld/HelloWorldRawRunner.java
@@ -1,0 +1,15 @@
+package demo.helloworld;
+
+import demo.AbstractTestBase;
+
+/**
+ * HelloWorldRunner
+ *
+ * @author thinkerou
+ */
+public class HelloWorldRawRunner extends AbstractTestBase {
+    @Override
+    protected String getFeatures() {
+        return "classpath:demo/helloworld/helloworld-raw.feature";
+    }
+}

--- a/karate-grpc-demo/src/test/java/demo/helloworld/helloworld-raw.feature
+++ b/karate-grpc-demo/src/test/java/demo/helloworld/helloworld-raw.feature
@@ -1,0 +1,22 @@
+Feature: grpc helloworld example using base GrpcCient
+
+  Background:
+    * def Client = Java.type('com.github.thinkerou.karate.GrpcClient')
+    * def client = new Client('localhost', 50051)
+
+  Scenario: do it
+    * def testHeaderValue = 'testing gRPC headers'
+    * configure headers = { 'karate-test-header': "#(testHeaderValue)" }
+    * string payload = read('helloworld.json')
+    * def response = client.call("helloworld.Greeter/SayHello", payload, karate)
+    # I'm not sure why this isn't exposed in Karate's "match header", but this suits
+    # for our immediate needs of supporting gRPC client headers.
+    * assert responseHeaders['karate-test-server-header'][0] == testHeaderValue
+    * def reply = JSON.parse(response)
+    * match reply[0].message == 'Hello thinkerou'
+    * def message = reply[0].message
+
+    * string payload2 = read('again-helloworld.json')
+    * def response2 = client.call("helloworld.Greeter/AgainSayHello", payload2, karate)
+    * def reply2 = JSON.parse(response2)
+    * match reply2[0].details == 'Details Hello thinkerou in BeiJing'

--- a/karate-grpc-helper/pom.xml
+++ b/karate-grpc-helper/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>karate-grpc-parent</artifactId>
         <groupId>com.github.thinkerou</groupId>
-        <version>1.0.6</version>
+        <version>1.0.7</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/karate-grpc-proto/pom.xml
+++ b/karate-grpc-proto/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>karate-grpc-parent</artifactId>
         <groupId>com.github.thinkerou</groupId>
-        <version>1.0.6</version>
+        <version>1.0.7</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.github.thinkerou</groupId>
     <artifactId>karate-grpc-parent</artifactId>
     <packaging>pom</packaging>
-    <version>1.0.6</version>
+    <version>1.0.7</version>
 
     <name>${project.artifactId}</name>
     <description>gRPC Testing Made Simple by Karate.</description>


### PR DESCRIPTION
Passes header configuration from Karate's ScenarioBridge to the gRPC
client calls (when the 3rd argument to call() is supplied).
The test server also looks for a specific header called
`karate-test-header` and puts the value in a response header called
`karate-test-server-header` in order to provide a test scenario in
`helloworld-raw.feature`.

* Fixes pecker-io/karate-grpc#35