### PR TITLE
ISSUE-35/fix-breaking-tests

### DIFF
--- a/karate-grpc-demo/src/main/java/com/github/thinkerou/demo/helloworld/HeaderServerInterceptor.java
+++ b/karate-grpc-demo/src/main/java/com/github/thinkerou/demo/helloworld/HeaderServerInterceptor.java
@@ -29,7 +29,9 @@ public class HeaderServerInterceptor implements ServerInterceptor {
             @Override
             public void sendHeaders(Metadata responseHeaders) {
                 logger.debug("Found special header value: {}", clientSpecialHeaderValue);
-                responseHeaders.put(CUSTOM_HEADER_KEY, clientSpecialHeaderValue);
+                if(responseHeaders != null && clientSpecialHeaderValue != null){
+                    responseHeaders.put(CUSTOM_HEADER_KEY, clientSpecialHeaderValue);
+                }
                 super.sendHeaders(responseHeaders);
             }
         }, requestHeaders);


### PR DESCRIPTION
The HeaderServerInterceptor was broken under the condition that the
custom header was _NOT_ sent.